### PR TITLE
sync-all.sh: only run for OpenShift images

### DIFF
--- a/sync-all.sh
+++ b/sync-all.sh
@@ -3,4 +3,7 @@ set -u
 set -e
 
 git submodule update --remote --force
-git submodule foreach "../../sync.sh"
+git submodule foreach --quiet '
+    if echo "$name" | grep -q openshift; then
+        ../../sync.sh;
+    fi'


### PR DESCRIPTION
Determined by presence of "openshift" in the repository name.

I've left the non-openshift submodules in for now, as we plan to add
a standalone-specific pull template.